### PR TITLE
[FE] 💄 92) 자유게시판 댓글

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -134,6 +134,10 @@ const router = createBrowserRouter([
                 element: <InfoRegister />,
             },
             {
+                path: "/infos/:infoId/edit",
+                element: <InfoRegister />,
+            },
+            {
                 path: "/questions/add",
                 element: <QuestionRegister />,
             },

--- a/client/src/common-component/Header.tsx
+++ b/client/src/common-component/Header.tsx
@@ -1,13 +1,19 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 
-import { useRecoilState } from "recoil";
-import { isSignPageAtom } from "@feature/Global";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import { isLoggedInAtom, isSignPageAtom } from "@feature/Global";
+
+import { useToast } from "@hook/useToast";
 
 import IconLogo from "@assets/icon_logo.png";
 import IconLogoText from "@assets/icon_logo-text.png";
 import Typography from "@component/Typography";
 import SignButton from "@container/sign/component/SignButton";
+import { setTokenToLocalStorage, isExistToken } from "@util/token-helper";
+import { clearStorage } from "@util/localstorage-helper";
+
+const tempAccessToken = import.meta.env.VITE_APP_TEMP_ACCESS_TOKEN || "";
 
 type INavItem = {
     label: string;
@@ -16,11 +22,83 @@ type INavItem = {
 };
 type INavItems = Array<INavItem>;
 
+const NavItem = ({ item, onClickNavItem }: { item: INavItem; onClickNavItem: (item: INavItem) => void }) => {
+    const navigate = useNavigate();
+
+    return (
+        <li
+            onClick={() => {
+                navigate(item.route);
+            }}
+        >
+            <button className="mr-16 w-max font-spoqa text-18 font-medium" onClick={() => onClickNavItem(item)}>
+                <Typography type="Label" text={item.label} color={`${item.selected ? "text-main" : ""}`} />
+            </button>
+        </li>
+    );
+};
+
+const AuthBtns = ({ onLogoutHandler }: { onLogoutHandler: () => void }) => {
+    const navigate = useNavigate();
+    const { createToast } = useToast();
+    const [isLoggedIn, setIsLoggedIn] = useRecoilState(isLoggedInAtom);
+
+    if (isLoggedIn) {
+        return (
+            <div className="flex">
+                <button className="w-80 min-w-70 rounded-sm px-8" onClick={onLogoutHandler}>
+                    <Typography type="Body" text="Logout" color="text-warn" />
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex">
+            <SignButton
+                type="OUTLINED"
+                styles="px-8 w-80 rounded-sm mr-4 min-w-70"
+                onClickHandler={() => {
+                    // TODO: 로그인 후 처리해야할 부분
+                    // 1. 응답 headers의 authorization에서 access token을 받아온다
+                    const accessToken = tempAccessToken;
+                    // 2. access token과 파싱된 payload를 로컬스토리지에 저장한다.
+                    setTokenToLocalStorage(accessToken);
+                    // 3. isLoggedIn 전역 상태를 true로 바꿔준다.
+                    setIsLoggedIn(true);
+                    createToast({
+                        content: (
+                            <Typography
+                                type="SmallLabel"
+                                text={
+                                    "아직 로그인 api 연동 전이라 임시 로그인 입니다!\n이제 임시적으로 로그인된 것처럼 화면 동작이 일어날 거에요!\nㅤ\n혹시 정말 로그인 화면으로 이동하고 싶으셨다면 예 버튼을 눌러주세요!"
+                                }
+                            />
+                        ),
+                        isConfirm: true,
+                        callback: () => navigate("/login"),
+                    });
+                }}
+            >
+                <Typography type="Body" text="로그인" />
+            </SignButton>
+            <SignButton
+                type="FILLED"
+                styles="px-8 w-80 rounded-sm min-w-70"
+                onClickHandler={() => navigate("/signup/1")}
+            >
+                <Typography type="Body" text="회원가입" color="text-white" />
+            </SignButton>
+        </div>
+    );
+};
+
 function Header() {
     const navigate = useNavigate();
     const { pathname } = useLocation();
 
     const [isSignPage, setIsSignPage] = useRecoilState(isSignPageAtom);
+    const setIsLoggined = useSetRecoilState(isLoggedInAtom);
 
     const defaultNavItems: INavItems = [
         { label: "프로젝트", route: "/projects", selected: false },
@@ -43,13 +121,26 @@ function Header() {
 
         if (pathname.includes("/signup/1") || pathname.includes("/login")) {
             setIsSignPage(true);
+            onLogoutHandler();
         } else {
             setIsSignPage(false);
+            if (isExistToken()) {
+                setIsLoggined(true);
+            } else {
+                setIsLoggined(false);
+            }
         }
 
         // navItems 추가 시 exceeded update
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [pathname]);
+
+    const onLogoutHandler = () => {
+        // 회원가입 / 로그인 페이지로 이동할 경우 로그인 풀리도록 설정
+        clearStorage();
+        setIsLoggined(false);
+        // TODO: 로그아웃 api 요청
+    };
 
     const onClickNavItem = (item: INavItem) => {
         setNavItems(
@@ -63,41 +154,6 @@ function Header() {
         );
     };
 
-    const NavItem = ({ item }: { item: INavItem }) => {
-        return (
-            <li
-                onClick={() => {
-                    navigate(item.route);
-                }}
-            >
-                <button className="mr-16 w-max font-spoqa text-18 font-medium" onClick={() => onClickNavItem(item)}>
-                    <Typography type="Label" text={item.label} color={`${item.selected ? "text-main" : ""}`} />
-                </button>
-            </li>
-        );
-    };
-
-    const AuthBtns = () => {
-        return (
-            <div className="flex">
-                <SignButton
-                    type="OUTLINED"
-                    styles="px-8 w-80 rounded-sm mr-4 min-w-70"
-                    onClickHandler={() => navigate("/login")}
-                >
-                    <Typography type="Body" text="로그인" />
-                </SignButton>
-                <SignButton
-                    type="FILLED"
-                    styles="px-8 w-80 rounded-sm min-w-70"
-                    onClickHandler={() => navigate("/signup/1")}
-                >
-                    <Typography type="Body" text="회원가입" color="text-white" />
-                </SignButton>
-            </div>
-        );
-    };
-
     return (
         <>
             <header className="flex h-60 w-full items-center justify-between px-10 lg:p-0">
@@ -107,13 +163,13 @@ function Header() {
                     <img src={IconLogoText} width={200} alt="DevSquad" className="hidden sm:block" />
                 </button>
 
-                {!isSignPage ? <AuthBtns /> : null}
+                {!isSignPage ? <AuthBtns onLogoutHandler={onLogoutHandler} /> : null}
             </header>
             {!isSignPage ? (
                 <nav className="flex h-50 w-full border-b-1 border-borderline px-10 lg:p-0">
                     <ul className="flex w-full items-center overflow-x-scroll sm:overflow-hidden">
                         {navItems.map((v: INavItem) => (
-                            <NavItem key={v.label} item={v} />
+                            <NavItem key={v.label} item={v} onClickNavItem={onClickNavItem} />
                         ))}
                     </ul>
                 </nav>

--- a/client/src/common-component/Toast.tsx
+++ b/client/src/common-component/Toast.tsx
@@ -11,7 +11,7 @@ function Toast({ toast }: { toast: IToast }) {
     const [isShow, setIsShow] = useState(true);
     const { removeToast } = useToast();
 
-    const defaultCss = "flex justify-between min-w-500 w-max px-18 py-12 mb-6 rounded-xl shadow-md";
+    const defaultCss = "flex justify-between min-w-500 w-max px-18 py-12 mb-6 rounded-xl shadow-md z-50";
 
     const handleCloseToast = () => {
         setIsShow(false);
@@ -19,7 +19,6 @@ function Toast({ toast }: { toast: IToast }) {
     };
 
     const handleConfirmToast = () => {
-        console.log(toast.callback);
         if (toast.callback) {
             toast.callback();
         }

--- a/client/src/common-component/ToastList.tsx
+++ b/client/src/common-component/ToastList.tsx
@@ -7,7 +7,7 @@ function ToastList() {
     const toasts = useRecoilValue(toastState);
 
     return (
-        <div className="fixed left-2/4 top-120 -translate-x-2/4">
+        <div className="fixed left-2/4 top-180 -translate-x-2/4">
             {toasts.map((v) => (
                 <Toast key={v.id} toast={v} />
             ))}

--- a/client/src/common-component/Typography.tsx
+++ b/client/src/common-component/Typography.tsx
@@ -21,42 +21,82 @@ function Text({
     color?: string;
     styles?: string;
 }) {
-    const renderText = () => {
+    const renderText = (textValue: string) => {
         const colorAndStyle = `${color ? color : ""} ${styles ? styles : ""}`;
 
         if (type === "Logo") {
-            return <p className={`font-ganpan text-40 font-bold ${colorAndStyle}`}>{text}</p>;
+            return (
+                <p key={textValue} className={`font-ganpan text-40 font-bold ${colorAndStyle}`}>
+                    {textValue}
+                </p>
+            );
         }
 
         if (type === "Heading") {
-            return <p className={`text-32 font-bold ${colorAndStyle}`}>{text}</p>;
+            return (
+                <p key={textValue} className={`text-32 font-bold ${colorAndStyle}`}>
+                    {textValue}
+                </p>
+            );
         }
 
         if (type === "SubHeading") {
-            return <p className={`text-24 font-bold ${colorAndStyle}`}>{text}</p>;
+            return (
+                <p key={textValue} className={`text-24 font-bold ${colorAndStyle}`}>
+                    {textValue}
+                </p>
+            );
         }
 
         if (type === "Label") {
-            return <p className={`font-spoqa text-20 font-medium ${colorAndStyle}`}>{text}</p>;
+            return (
+                <p key={textValue} className={`font-spoqa text-20 font-medium ${colorAndStyle}`}>
+                    {textValue}
+                </p>
+            );
         }
 
         if (type === "Highlight") {
-            return <p className={`text-base font-semibold ${colorAndStyle}`}>{text}</p>;
+            return (
+                <p key={textValue} className={`text-base font-semibold ${colorAndStyle}`}>
+                    {textValue}
+                </p>
+            );
         }
 
         if (type === "Body") {
-            return <p className={`text-base ${colorAndStyle}`}>{text}</p>;
+            return (
+                <p key={textValue} className={`text-base ${colorAndStyle}`}>
+                    {textValue}
+                </p>
+            );
         }
 
         if (type === "SmallLabel") {
-            return <p className={`text-sm ${colorAndStyle}`}>{text}</p>;
+            return (
+                <p key={textValue} className={`text-sm ${colorAndStyle}`}>
+                    {textValue}
+                </p>
+            );
         }
 
         if (type === "Description") {
-            return <p className={`text-xs ${colorAndStyle}`}>{text}</p>;
+            return (
+                <p key={textValue} className={`text-xs ${colorAndStyle}`}>
+                    {textValue}
+                </p>
+            );
         }
     };
-    return <>{renderText()}</>;
+    return (
+        <>
+            {text.includes("\n")
+                ? text.split("\n").map((v) => {
+                      return renderText(v);
+                  })
+                : renderText(text)}
+        </>
+    );
 }
 
 export const Typography = memo(Text); // 불필요한 렌더링을 방지해주는 기능: memo

--- a/client/src/common-component/board/Comment.tsx
+++ b/client/src/common-component/board/Comment.tsx
@@ -54,8 +54,7 @@ export const EditComment = ({ value = "", onChange, onSubmitHanlder }: IComment)
 };
 
 export const ShowComment = ({ comment }: { comment: CommentDefaultType }) => {
-    console.log(comment);
-    // TODO: 내 아이디와 info member 아이디가 같은지 확인
+    // TODO: 내 아이디와 로컬스토리지에 저장된 member 아이디가 같은지 확인
     // const [isMine, setIsMine] = useState(true);
     const { data: user } = useGetMemberDetail({ memberId: comment.memberId });
 

--- a/client/src/common-component/board/Comment.tsx
+++ b/client/src/common-component/board/Comment.tsx
@@ -1,13 +1,21 @@
-import dayjs from "dayjs";
+import { useState } from "react";
+
 import { useGetMemberDetail } from "@api/member/hook";
+import { usePatchComment, useDeleteComment } from "@api/comment/hook";
+
+import { useToast } from "@hook/useToast";
+import { useCheckUser } from "@hook/useCheckUser";
+import { useCheckEmptyInput } from "@hook/useCheckEmptyInput";
+
+import dayjs from "dayjs";
 
 import Textarea, { ITextarea } from "@component/Textarea";
 import Button from "@component/Button";
 import Typography from "@component/Typography";
 
-import { CommentDefaultType } from "@type/comment/comment.res.dto";
+import { CommentDefaultTypeWithRe } from "@type/comment/comment.res.dto";
 
-import { BiPencil } from "react-icons/bi";
+import { BiPencil, BiReply } from "react-icons/bi";
 import { RiReplyLine, RiDeleteBin5Line } from "react-icons/ri";
 
 interface IComment extends ITextarea {
@@ -28,7 +36,7 @@ const dummyUser = {
 
 export const EditComment = ({ value = "", onChange, onSubmitHanlder }: IComment) => {
     return (
-        <div className="flex flex-col">
+        <div className="flex flex-col border-b-1 border-borderline py-12">
             <div className="flex">
                 <div className="mr-8 h-36 w-36 overflow-hidden rounded border-1 border-borderline">
                     <img src={dummyUser.profilePicture} alt="" />
@@ -53,34 +61,204 @@ export const EditComment = ({ value = "", onChange, onSubmitHanlder }: IComment)
     );
 };
 
-export const ShowComment = ({ comment }: { comment: CommentDefaultType }) => {
-    // TODO: 내 아이디와 로컬스토리지에 저장된 member 아이디가 같은지 확인
-    // const [isMine, setIsMine] = useState(true);
-    const { data: user } = useGetMemberDetail({ memberId: comment.memberId });
+export const OneComment = ({ v, writerId }: { v: CommentDefaultTypeWithRe; writerId: number }) => {
+    const { data: user } = useGetMemberDetail({ memberId: v.memberId });
+    const { isLoggedIn, isMine, isSameUser } = useCheckUser({ memberId: v.memberId, comparedMemberId: writerId });
+
+    const [isEdit, setIsEdit] = useState(false);
+    const [curCommment, setCurComment] = useState(v.content);
+    const [parentId, setParentId] = useState(0);
+    const [nextComment, setNextComment] = useState("");
+
+    const { fireToast, createToast } = useToast();
+    const { alertWhenEmptyFn } = useCheckEmptyInput();
+    const { mutate: patchComment } = usePatchComment();
+    const { mutate: deleteComment } = useDeleteComment();
+
+    const onChangeCurComment = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setCurComment(e.currentTarget.value);
+    };
+
+    const onChangeNextComment = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setNextComment(e.currentTarget.value);
+    };
+
+    const onSubmitHanlder = () => {
+        const inputs = [{ name: "댓글", content: curCommment }];
+        const emptyNames = alertWhenEmptyFn(inputs);
+
+        if (emptyNames.length === 0) {
+            patchComment(
+                { board: "information", boardId: v.boardId, commentId: v.commentId, content: curCommment },
+                {
+                    onSuccess: () => {
+                        fireToast({
+                            content: "댓글이 수정되었습니다!",
+                            isConfirm: false,
+                        });
+                    },
+                    // TODO: 에러 분기
+                    onError: (err) => {
+                        console.log(err);
+                        fireToast({
+                            content: "댓글 수정 중 에러가 발생하였습니다. 새로 고침하여 다시 시도해주세요🥹",
+                            isConfirm: false,
+                            isWarning: true,
+                        });
+                    },
+                    onSettled: () => setIsEdit(false),
+                },
+            );
+        }
+    };
+
+    const onDeleteHanlder = () => {
+        createToast({
+            content: "해당 댓글을 삭제하시겠습니까?",
+            isConfirm: true,
+            callback: () => {
+                deleteComment(
+                    { board: "information", boardId: v.boardId, commentId: v.commentId },
+                    {
+                        onSuccess: () => {
+                            fireToast({
+                                content: "댓글이 삭제되었습니다!",
+                                isConfirm: false,
+                            });
+                            // TODO: 댓글 리스트 조회
+                        },
+                        onError: () => {
+                            fireToast({
+                                content: "댓글 삭제에 실패하였습니다. 새로고침 후 다시 삭제 시도부탁드려요!🥹",
+                                isConfirm: false,
+                                isWarning: true,
+                            });
+                        },
+                    },
+                );
+            },
+        });
+    };
 
     return (
-        <div className="mb-8 flex flex-col border-b-1 border-borderline">
+        <>
             <div className="relative flex items-center justify-between">
                 <div className="flex items-center">
                     <div className="mr-8 h-36 w-36 overflow-hidden rounded border-1 border-borderline">
                         {user && <img src={user.profilePicture} alt="" />}
                     </div>
-                    <Typography type="Highlight" text={comment.nickname} />
+                    <Typography type="Highlight" text={v.nickname} />
+                    {isSameUser && (
+                        <div className="ml-12 rounded-sm border-1 border-blue-200 px-4 py-2">
+                            <Typography type="SmallLabel" text="작성자" color="text-blue-500" />
+                        </div>
+                    )}
                 </div>
-                <Typography
-                    type="Description"
-                    text={dayjs(comment.modifiedAt).format("YYYY-MM-DD")}
-                    color="text-gray-600"
-                />
-                <div className="absolute right-0 top-32 flex w-70 justify-between">
-                    <BiPencil size={"1.2rem"} />
-                    <RiDeleteBin5Line size={"1.2rem"} />
-                    <RiReplyLine size={"1.2rem"} />
+                {isEdit ? (
+                    <button onClick={onSubmitHanlder}>
+                        <Typography
+                            type="Description"
+                            text="수정 완료"
+                            color="text-blue-400 hover:text-blue-700 cursor-pointer"
+                        />
+                    </button>
+                ) : (
+                    <Typography
+                        type="Description"
+                        text={dayjs(v.modifiedAt).format("YYYY-MM-DD")}
+                        color="text-gray-600"
+                    />
+                )}
+                {isLoggedIn && !isEdit && (
+                    <div className={`absolute right-0 top-32 flex w-70 ${isMine ? "justify-between" : "justify-end"}`}>
+                        {isMine && (
+                            <>
+                                <button onClick={() => setIsEdit(true)}>
+                                    <BiPencil size={"1.2rem"} />
+                                </button>
+                                <button onClick={onDeleteHanlder}>
+                                    <RiDeleteBin5Line size={"1.2rem"} />
+                                </button>
+                            </>
+                        )}
+                        <button onClick={() => setParentId(v.commentId)}>
+                            <RiReplyLine size={"1.2rem"} />
+                        </button>
+                    </div>
+                )}
+            </div>
+            {isEdit ? (
+                <div className="my-12">
+                    <Textarea
+                        name="curComment"
+                        maxlength={200}
+                        value={curCommment}
+                        onChange={onChangeCurComment}
+                        borderStyle="border-1 border-borderline shadow-md"
+                    />
                 </div>
-            </div>
-            <div className="my-12">
-                <div>{comment.content}</div>
-            </div>
+            ) : (
+                <div className="my-12">
+                    {v.commentStatus === "COMMENT_POSTED" ? (
+                        <Typography type="Body" text={curCommment} />
+                    ) : (
+                        <Typography type="Body" text="삭제된 댓글입니다." color="text-gray-700" />
+                    )}
+                </div>
+            )}
+            {parentId > 0 && (
+                <div className="my-12 flex-col">
+                    <div className="mb-8 flex items-center justify-between">
+                        <div className="flex items-center">
+                            <div className="flex rotate-180 items-end p-8">
+                                <BiReply />
+                            </div>
+                            <div className="mr-8 h-36 w-36 overflow-hidden rounded border-1 border-borderline">
+                                <img src={dummyUser.profilePicture} alt="" />
+                            </div>
+                            <Typography type="Highlight" text={dummyUser.nickname} />
+                        </div>
+
+                        <button onClick={() => {}}>
+                            <Typography
+                                type="Description"
+                                text="등록"
+                                color="text-blue-400 hover:text-blue-700 cursor-pointer"
+                            />
+                        </button>
+                    </div>
+                    <div className="ml-32 flex-1">
+                        <Textarea
+                            name="nextComment"
+                            maxlength={200}
+                            value={nextComment}
+                            onChange={onChangeNextComment}
+                            borderStyle="border-1 border-borderline shadow-md"
+                        />
+                    </div>
+                </div>
+            )}
+
+            {Array.isArray(v.commentList) &&
+                v.commentList.length > 0 &&
+                v.commentList.map((v) => (
+                    <div className="flex">
+                        <div className="flex rotate-180 items-end p-8">
+                            <BiReply />
+                        </div>
+                        <div className="flex-1">
+                            <OneComment v={v} writerId={writerId} />
+                        </div>
+                    </div>
+                ))}
+        </>
+    );
+};
+
+export const ShowComment = ({ comment, writerId }: { comment: CommentDefaultTypeWithRe; writerId: number }) => {
+    return (
+        <div className="mb-8 flex flex-col border-b-1 border-borderline">
+            <OneComment v={comment} writerId={writerId} />
         </div>
     );
 };

--- a/client/src/container/info/Board.tsx
+++ b/client/src/container/info/Board.tsx
@@ -1,7 +1,11 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { useRecoilValue } from "recoil";
+import { isLoggedInAtom } from "@feature/Global";
+
 import { useGetAllInfo } from "@api/info/hook";
+import { useToast } from "@hook/useToast";
 
 import Button from "@component/Button";
 import Typography from "@component/Typography";
@@ -13,6 +17,10 @@ import { CATEGORY_TO_ENUM } from "@api/info/constant";
 
 function Board() {
     const navigate = useNavigate();
+    const { reqLoginToUserToast } = useToast();
+
+    const isLogginedIn = useRecoilValue(isLoggedInAtom);
+
     // 검색 버튼 또는 엔터를 눌렀을 때 조회하기 위한 검색 파라미터
     const [search, setSearch] = useState<string>("");
     // 검색 인풋 value 저장하기 위한 변수
@@ -34,6 +42,14 @@ function Board() {
         }
     };
 
+    const onClickRegisterHandler = () => {
+        if (isLogginedIn) {
+            navigate("/infos/add");
+        } else {
+            reqLoginToUserToast();
+        }
+    };
+
     return (
         <>
             <div className="fixed z-10 flex w-full max-w-screen-xl border-b-1 border-borderline bg-white">
@@ -47,7 +63,7 @@ function Board() {
                     />
                 </div>
                 <div className="hidden w-300 justify-end p-10 lg:flex">
-                    <Button type="INFO_POINT" onClickHandler={() => navigate("/infos/add")}>
+                    <Button type="INFO_POINT" onClickHandler={onClickRegisterHandler}>
                         <Typography type="Highlight" text="자유게시글 등록" />
                     </Button>
                 </div>

--- a/client/src/container/info/Register.tsx
+++ b/client/src/container/info/Register.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 
-import { usePostInfo } from "@api/info/hook";
+import { usePostInfo, usePatchInfo } from "@api/info/hook";
 import { useToast } from "@hook/useToast";
 import { useCheckEmptyInput } from "@hook/useCheckEmptyInput";
+import { useCheckCurActivity } from "@hook/useCheckCurActivity";
 
 import Typography from "@component/Typography";
 import Button from "@component/Button";
@@ -12,12 +13,17 @@ import BoardContent from "@component/board/BoardContent";
 import Dropdown from "@component/board/Dropdown";
 
 import { infoCategory } from "@component/mockData";
-import { CATEGORY_TO_ENUM } from "@api/info/constant";
+import { CATEGORY_TO_ENUM, CATEGORY_TO_NAME } from "@api/info/constant";
 import { CATEGORY_NAME } from "@type/info/common";
+import { InfoDefaultType } from "@type/info/info.res.dto";
 
 function Register() {
     const navigate = useNavigate();
+    const location = useLocation();
+    const { curActivity } = useCheckCurActivity({ location });
+
     const { mutate: postInfo } = usePostInfo();
+    const { mutate: patchInfo } = usePatchInfo();
     const { alertWhenEmptyFn } = useCheckEmptyInput();
     const { fireToast } = useToast();
 
@@ -27,20 +33,32 @@ function Register() {
     const [title, setTitle] = useState("");
     const [content, setContent] = useState("");
 
+    useEffect(() => {
+        if (curActivity === "EDIT") {
+            const { title: prevTitle, content: prevContent, category }: InfoDefaultType = location.state;
+
+            setTitle(prevTitle);
+            setContent(prevContent);
+            setSelectedItem(CATEGORY_TO_NAME[category]);
+        }
+    }, [curActivity]);
+
     const titleChangHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
         setTitle(e.currentTarget.value);
     };
 
-    const onClickHandler = () => {
+    const isEmpty = () => {
         const inputs = [
             { name: "카테고리", content: selectedItem },
             { name: "제목", content: title },
             { name: "상세내용", content },
         ];
         const emptyNames = alertWhenEmptyFn(inputs);
-        if (emptyNames.length > 0) {
-            return;
-        }
+        return emptyNames.length > 0;
+    };
+
+    const onPostClickHandler = () => {
+        if (isEmpty()) return;
 
         if (selectedItem !== "") {
             postInfo(
@@ -68,10 +86,41 @@ function Register() {
         }
     };
 
+    const onPatchClickHandler = () => {
+        if (isEmpty()) return;
+
+        patchInfo(
+            { infoId: location.state.boardId, title, content, category: CATEGORY_TO_ENUM[selectedItem || "뉴스 레터"] },
+            {
+                onSuccess: () => {
+                    navigate("/infos");
+
+                    fireToast({
+                        content: "게시글이 수정되었습니다!",
+                        isConfirm: false,
+                    });
+                },
+                // TODO: 에러 분기
+                onError: (err) => {
+                    console.log(err);
+                    fireToast({
+                        content: "게시글 등록 중 에러가 발생하였습니다🥹",
+                        isConfirm: false,
+                        isWarning: true,
+                    });
+                },
+            },
+        );
+    };
+
     return (
         <div className="m-0 flex justify-center lg:m-80">
             <div className="flex w-full flex-col rounded-lg bg-info p-8 sm:px-30 sm:py-60 lg:w-11/12">
-                <Typography type="Heading" text="자유게시판 등록" styles="pl-10 self-baseline" />
+                <Typography
+                    type="Heading"
+                    text={`자유게시판 ${curActivity === "REGISTER" ? "등록" : "수정"}`}
+                    styles="pl-10 self-baseline"
+                />
 
                 <Dropdown
                     label="카테고리"
@@ -94,9 +143,15 @@ function Register() {
                 />
                 <BoardContent label="게시글 상세내용" required={true} content={content} setContent={setContent} />
                 <div className="flex w-full justify-center">
-                    <Button type="INFO_POINT" styles="mt-20" isFullBtn={false} onClickHandler={onClickHandler}>
-                        <Typography text="등록하기" type="Label" color="text-white" />
-                    </Button>
+                    {curActivity === "REGISTER" ? (
+                        <Button type="INFO_POINT" styles="mt-20" isFullBtn={false} onClickHandler={onPostClickHandler}>
+                            <Typography text="등록하기" type="Label" color="text-white" />
+                        </Button>
+                    ) : (
+                        <Button type="INFO_POINT" styles="mt-20" isFullBtn={false} onClickHandler={onPatchClickHandler}>
+                            <Typography text="수정하기" type="Label" color="text-white" />
+                        </Button>
+                    )}
                 </div>
             </div>
         </div>

--- a/client/src/container/info/component/InfoItem.tsx
+++ b/client/src/container/info/component/InfoItem.tsx
@@ -62,7 +62,7 @@ const InfoTitle = ({ info }: { info: InfoDefaultType }) => {
                     <Typography text={`조회수 ${viewCount}`} type="SmallLabel" color="text-gray-600" />
                 </div>
             </div>
-            <div className="mb-8 flex w-100 flex-col items-center justify-end">
+            <div className="mb-8 flex w-50 flex-col items-center justify-end">
                 <button onClick={() => setIsLiked(!isLiked)}>
                     <BsSuitHeartFill size="1.2rem" color={isLiked ? "#FF2222" : "#E2E2E2"} />
                 </button>

--- a/client/src/container/user/List.tsx
+++ b/client/src/container/user/List.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect } from "react";
 
 import UserCard from "@component/board/UserCard";
 import Pagination from "@component/Pagination";
+import SearchFilter from "@container/user/component/SearchFilter";
 
 import { useGetAllMembers } from "@api/member/hook";
-import SearchFilter from "@container/user/component/SearchFilter";
 
 function UserList() {
     // 페이지 필터

--- a/client/src/feature/Global.ts
+++ b/client/src/feature/Global.ts
@@ -22,7 +22,13 @@ export const addToastItem = selector({
     key: "addToastItem",
     get: ({ get }) => get(toastState),
     set: ({ set }, newToast: IToast[] | DefaultValue) => {
-        set(toastState, (prevToast) => [...prevToast, ...(newToast as [])]);
+        set(toastState, (prevToast) => {
+            const toastIds = prevToast.map((v) => v.id);
+            if (Array.isArray(newToast) && newToast[0] && newToast[0].id && toastIds.includes(newToast[0].id)) {
+                return [...prevToast];
+            }
+            return [...prevToast, ...(newToast as [])];
+        });
     },
 });
 // 기능 2. id에 해당하는 toastItem 삭제

--- a/client/src/feature/Global.ts
+++ b/client/src/feature/Global.ts
@@ -7,6 +7,11 @@ export const isSignPageAtom = atom<boolean>({
     default: false,
 });
 
+export const isLoggedInAtom = atom<boolean>({
+    key: "isLoggedInAtom",
+    default: false,
+});
+
 export const toastState = atom<IToast[]>({
     key: "toastState",
     default: [],

--- a/client/src/hook/useCheckCurActivity.ts
+++ b/client/src/hook/useCheckCurActivity.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { useToast } from "./useToast";
+import { Location } from "react-router-dom";
+
+export type CurActivity = "REGISTER" | "EDIT" | "ERROR";
+
+export const useCheckCurActivity = ({ location }: { location: Location }): { curActivity: CurActivity } => {
+    const { fireToast } = useToast();
+    const [curActivity, setCurActivity] = useState<CurActivity>("REGISTER");
+
+    useEffect(() => {
+        if (location.pathname.includes("edit")) {
+            if (!location.state) {
+                fireToast({
+                    content: "올바른 접근이 아닙니다. 메인화면으로 이동합니다.",
+                    isConfirm: false,
+                    isWarning: false,
+                });
+                setCurActivity("ERROR");
+                window.location.href = "/";
+                return;
+            }
+
+            setCurActivity("EDIT");
+        } else {
+            setCurActivity("REGISTER");
+        }
+    }, []);
+
+    return { curActivity };
+};

--- a/client/src/hook/useCheckUser.ts
+++ b/client/src/hook/useCheckUser.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+import { useRecoilValue } from "recoil";
+import { isLoggedInAtom } from "@feature/Global";
+
+import { getItemFromStorage } from "@util/localstorage-helper";
+
+export const useCheckUser = ({ memberId, comparedMemberId }: { memberId: number; comparedMemberId?: number }) => {
+    const isLoggedIn = useRecoilValue(isLoggedInAtom);
+
+    const [isMine, setIsMine] = useState(false);
+    const storedMemberId = getItemFromStorage("memberId");
+
+    const [isSameUser, setIsSameUser] = useState(false);
+
+    useEffect(() => {
+        if (isLoggedIn) {
+            if (Number.parseInt(storedMemberId) === memberId) {
+                setIsMine(true);
+            }
+        } else {
+            setIsMine(false);
+        }
+    }, [isLoggedIn, memberId]);
+
+    useEffect(() => {
+        if (memberId && comparedMemberId) {
+            setIsSameUser(memberId === comparedMemberId);
+        }
+    }, [comparedMemberId]);
+
+    return { isLoggedIn, isMine, isSameUser };
+};

--- a/client/src/hook/useToast.ts
+++ b/client/src/hook/useToast.ts
@@ -58,5 +58,17 @@ export const useToast = () => {
         ]);
     };
 
-    return { toasts, createToast, removeToast, fireToast };
+    const reqLoginToUserToast = () => {
+        addToastItemFn([
+            {
+                id: id,
+                content: "로그인이 필요한 서비스입니다. 로그인 화면으로 이동하시겠습니까?",
+                isConfirm: true,
+                isWarning: false,
+                callback: () => (location.href = "/login"),
+            },
+        ]);
+    };
+
+    return { toasts, createToast, removeToast, fireToast, reqLoginToUserToast };
 };

--- a/client/src/type/comment/comment.res.dto.ts
+++ b/client/src/type/comment/comment.res.dto.ts
@@ -6,13 +6,13 @@ export interface CommentDefaultType {
     answerId: null | number;
     parentId: null | number;
     content: string;
-    commentStatus: string; // enum
+    commentStatus: "COMMENT_DELETED" | "COMMENT_POSTED";
     createdAt: string;
     modifiedAt: string;
 }
 
 export interface CommentDefaultTypeWithRe extends CommentDefaultType {
-    commentList: Array<CommentDefaultType>;
+    commentList: Array<CommentDefaultTypeWithRe>;
 }
 
 // 게시판 - 댓글 등록 - status code: 201

--- a/client/src/type/info/info.res.dto.ts
+++ b/client/src/type/info/info.res.dto.ts
@@ -1,5 +1,5 @@
 import { CATEGORY_TYPE } from "./common";
-import { CommentDefaultType } from "@type/comment/comment.res.dto";
+import { CommentDefaultTypeWithRe } from "@type/comment/comment.res.dto";
 
 export interface InfoDefaultType {
     boardId: number;
@@ -10,7 +10,7 @@ export interface InfoDefaultType {
     viewCount: number;
     category: CATEGORY_TYPE;
     infoBoardStatus: string;
-    commentList: Array<CommentDefaultType>;
+    commentList: Array<CommentDefaultTypeWithRe>;
     createdAt: string;
     modifiedAt: string;
 }

--- a/client/src/util/token-helper.ts
+++ b/client/src/util/token-helper.ts
@@ -1,11 +1,13 @@
 import dayjs from "dayjs";
 import jwt_decode from "jwt-decode";
+import { getItemFromStorage, setItemToStorage } from "./localstorage-helper";
 
 type USER_ROLE = "USER" | "ADMIN";
 
 type ACCESS_TOKEN = {
     roles: Array<USER_ROLE>;
     username: string;
+    memberId: number;
     sub: string;
     exp: Date;
 };
@@ -16,6 +18,9 @@ type ACCESS_TOKEN = {
  * @returns {ACCESS_TOKEN} 토큰을 파싱한 객체
  */
 export const parseJwt = (token: string): ACCESS_TOKEN => {
+    if (!token) {
+        throw Error("jwt 토큰이 유효하지 않습니다.");
+    }
     const decoded: ACCESS_TOKEN = jwt_decode(token);
     return decoded;
 };
@@ -25,7 +30,42 @@ export const parseJwt = (token: string): ACCESS_TOKEN => {
  * @param {string} token access token 또는 refresh token
  * @returns {boolean} 토큰 유효 여부
  */
-export const isValidToken = (token: string): boolean => {
+export const isValidToken = (token: string): boolean | undefined => {
+    if (!token) {
+        console.log("jwt 토큰이 유효하지 않습니다.", token);
+        return;
+    }
     const tokenJwtData = parseJwt(token);
-    return dayjs(tokenJwtData.exp) > dayjs();
+    console.log("실제 토큰 유효성 여부", dayjs(tokenJwtData.exp) > dayjs());
+    // return dayjs(tokenJwtData.exp) > dayjs();
+    // TODO: 로그인 api 연동 후에 삭제할 코드
+    return true;
+};
+
+export const isExistToken = (): boolean => {
+    const accessToken = getItemFromStorage("accessToken");
+    if (!accessToken) {
+        return false;
+    }
+
+    const tokenJwtData = parseJwt(accessToken);
+    console.log("토큰에 저장된 실제 memberId", tokenJwtData.memberId);
+    // TODO: 로그인 api 연동 후에 1 대신 tokenJwtData.memberId 넣기
+    //       - 타입 확인 후 == 를 === 로 바꾸기
+    return accessToken && getItemFromStorage("memberId") && getItemFromStorage("memberId") == 1;
+};
+
+export const setTokenToLocalStorage = (token: string): void => {
+    if (!token) {
+        console.log("jwt 토큰이 유효하지 않습니다.", token);
+        return;
+    }
+    const parsedToken = parseJwt(token);
+    // TODO: 로그인 api 연동 후에 삭제할 코드
+    setItemToStorage("isLoggedIn", true);
+    setItemToStorage("accessToken", token);
+    setItemToStorage("email", parsedToken.username);
+    setItemToStorage("role", parsedToken.roles);
+    // TODO: 로그인 api 연동 후에 삭제할 코드 (|| 1)
+    setItemToStorage("memberId", parsedToken.memberId || 1);
 };

--- a/client/src/util/token-helper.ts
+++ b/client/src/util/token-helper.ts
@@ -1,4 +1,4 @@
-import dayjs from "dayjs";
+// import dayjs from "dayjs";
 import jwt_decode from "jwt-decode";
 import { getItemFromStorage, setItemToStorage } from "./localstorage-helper";
 
@@ -35,9 +35,9 @@ export const isValidToken = (token: string): boolean | undefined => {
         console.log("jwt 토큰이 유효하지 않습니다.", token);
         return;
     }
-    const tokenJwtData = parseJwt(token);
-    console.log("실제 토큰 유효성 여부", dayjs(tokenJwtData.exp) > dayjs());
+    // const tokenJwtData = parseJwt(token);
     // return dayjs(tokenJwtData.exp) > dayjs();
+
     // TODO: 로그인 api 연동 후에 삭제할 코드
     return true;
 };
@@ -48,8 +48,7 @@ export const isExistToken = (): boolean => {
         return false;
     }
 
-    const tokenJwtData = parseJwt(accessToken);
-    console.log("토큰에 저장된 실제 memberId", tokenJwtData.memberId);
+    // const tokenJwtData = parseJwt(accessToken);
     // TODO: 로그인 api 연동 후에 1 대신 tokenJwtData.memberId 넣기
     //       - 타입 확인 후 == 를 === 로 바꾸기
     return accessToken && getItemFromStorage("memberId") && getItemFromStorage("memberId") == 1;


### PR DESCRIPTION
### 이슈번호

- #92 

### 작업 내용

- [x] 화면 구현

## 주요 로직

###  로직 수정 예정 (1. `@component/Header` 로그인 버튼)
- 로그인 api 연동 전 회원 기능/비회원 기능 분기를 적용하기 위해 임시적으로 헤더 로그인 버튼에 로그인 로직 순서대로 구현해두었습니다.
- 실제로 로그인 페이지로 이동하고 싶으실 경우 토스트의 "예" 버튼을 누르시면 됩니다!



https://github.com/codestates-seb/seb45_main_006/assets/126226314/0a0d3075-bc60-49b5-8754-b3dff48c6cf9

### 2. `@api/common/withAuthApi` 로컬스토리지의 토큰을 담아 요청 보내기 위한 axios 인스턴스 withAuthApi 수정 
- refresh token은 관리와, access token 만료시 새로운 access token 발급을 백엔드에서 맡아주셔서 토큰 유효성 검사 하는 이전 코드는 모두 주석처리하였습니다.
- 현재는 실제 토큰을 주고받지 않기 때문에 임시로 처리하였으며, 추후 api 연동 후 수정할 예정입니다.
```
// 응답 intercepter - 응답으로 받은 access token 유효할 경우 로컬스토리지에 저장
//                             - 유효하지 않을 경우 로컬스토리지에서 삭제 => 헤더 useEffect에서 체크 후 로그아웃 처리
withAuthApi.interceptors.response.use(async (config) => {
        const newAccessToken = config.headers.Authorization;
        if (newAccessToken && typeof newAccessToken === "string" && isValidToken(newAccessToken.split(" ")[1]))
            setTokenToLocalStorage(newAccessToken.split(" ")[1]);
        else
            clearStorage();
        return config;
});
```

### 3. `@feature/Global`토스트 알림 중복 방지
- 종종 토스트 알림이 중복으로 여러개 뜨는 상황을 해결하고자 id 중복 체크 로직을 추가하였습니다.
```
set(toastState, (prevToast) => {
    const toastIds = prevToast.map((v) => v.id);
    if (Array.isArray(newToast) && newToast[0] && newToast[0].id && toastIds.includes(newToast[0].id)) {
        return [...prevToast];
    }
    return [...prevToast, ...(newToast as [])];
});
```

### 4. `@hook/useToast` 비회원이 회원 기능을 사용하려고 할 때 알림
- 로그인 화면으로 이동할지 여부를 물어보고 "예"라고 답할 경우에만 로그인 화면으로 이동합니다.
```
const reqLoginToUserToast = () => {
        addToastItemFn([
            {
                id: id,
                content: "로그인이 필요한 서비스입니다. 로그인 화면으로 이동하시겠습니까?",
                isConfirm: true,
                isWarning: false,
                callback: () => (location.href = "/login"),
            },
        ]);
    };
```

https://github.com/codestates-seb/seb45_main_006/assets/126226314/016dabf6-ef2a-44fc-8230-f14d1c46ba67

### 5. `@hook/useCheckUser` 유저 관련하여 분기해아하는 부분을 정리한 hook
```
  - isLoggedIn: 유저가 로그인한 유저인지,
  - isMine: 입력받은 글 혹은 댓글의 memberId가 내 아이디와 일치하는지
  - isSameUser: 입력받은 memberId와 compareMemberId가 일치하는지 (글 작성자와 댓글 작성자가 일치하는지 확인)
```

### 6. `@hook/useCheckCurActivity`게시판(프로젝트, 스터디, 자유게시판, 질문게시판) 등록/수정 페이지 하나의 컴포넌트에서 관리하기 위해
- 현재 페이지가 "등록 페이지" 인지, "수정 페이지" 인지, 잘못된 접근인지 분기해주는 hook 추가
```
export type CurActivity = "REGISTER" | "EDIT" | "ERROR";

if (location.pathname.includes("edit")) {
      if (!location.state) {
          fireToast({
              content: "올바른 접근이 아닙니다. 메인화면으로 이동합니다.",
              isConfirm: false,
              isWarning: false,
          });
          setCurActivity("ERROR");
          window.location.href = "/";
          return;
      }

      setCurActivity("EDIT");
  } else {
      setCurActivity("REGISTER");
  }

```
### 결과 화면

1. 자유 게시판 조회 / 등록 / 수정 / 삭제


https://github.com/codestates-seb/seb45_main_006/assets/126226314/0494a9cc-9f60-420d-a32e-86ead82d763e


2. 댓글 조회 / 등록 / 수정 / 삭제 / 대댓글 등록


https://github.com/codestates-seb/seb45_main_006/assets/126226314/5af3f1be-53f4-4535-bb34-56bbf48f6e49


### 작업 중 이슈 사항 또는 TODO 로 남겨둔 부분
- 인증 관련
  - 토큰 관련 부분 수정하기
  - 이메일 인증 버튼, 인풋 추가 & html css 인라인으로 수정
- member 관련 변경된 api 적용
- 유저 상세 화면 추가
- 프로젝트, 스터디 관련
  - 프로젝트, 스터디 댓글 관련 api 연동
  - enum 체크하고 타입 수정
  - 페이징 필터 추가
- 마크다운
  - ol, ul 디자인이 tailwindcss @base(reset css 관련) 때문에 보이지 않는 이슈
  - 스크롤 css 적용
- 자유게시판, 질문 게시판
  - 인기순, 페이징 필터
  - 북마크, 좋아요 관련 api 추가 
  - 댓글 생성, 삭제 시 댓글 리스트 조회 api 요청 보내기
  - 수정 후 상세 게시글 바로 조회할 수 있도록 방법 찾기
  - 질문 게시판 페이지네이션으로 바꾸기